### PR TITLE
Upgrade to requests 2.30.0 and urllib3 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@ psycopg2-binary==2.9.3
 pycparser==2.21
 PyJWT==2.4.0
 python3-openid==3.2.0
-requests==2.28.1
+requests==2.30.0
 requests-oauthlib==1.3.1
 sqlparse==0.4.2
-urllib3==1.26.13
+urllib3==2.0.2
 whitenoise==6.0.0


### PR DESCRIPTION
Hello, urllib3 maintainer here :wave: 

To upgrade to the next release version of urllib3, requests need to be upgraded too, which is something that dependabot does not handle well, see https://github.com/lolrenx/pf-wagtail/pull/140 for an example.